### PR TITLE
allow the depwarn to be forced

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ julia> foo(old_kw1=1, new_kw2=2)
 ```
 
 `@depkws` accepts an optional argument to force the deprecation warning to emit regardless of the `--depwarn` setting.
-If omitted, the default is `force_depwarn=false`, which means the deprecation warning will only be shown if the user has `--depwarn=yes` set.
+If omitted, the default is `force=false`, which means the deprecation warning will only be shown if the user has `--depwarn=yes` set.
 
 ```julia
-julia> @depkws force_depwarn=true function foo(; new_kw1=2, new_kw2=3,
+julia> @depkws force=true function foo(; new_kw1=2, new_kw2=3,
                        @deprecate(old_kw1, new_kw1),
                        @deprecate(old_kw2, new_kw2))
     return new_kw1 + new_kw2

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ julia> foo(old_kw1=1, new_kw2=2)
 If omitted, the default is `force=false`, which means the deprecation warning will only be shown if the user has `--depwarn=yes` set.
 
 ```julia
-julia> @depkws function foo(; new_kw1=2, new_kw2=3,
+julia> @depkws force=true function foo(; new_kw1=2, new_kw2=3,
                        @deprecate(old_kw1, new_kw1),
                        @deprecate(old_kw2, new_kw2))
     return new_kw1 + new_kw2
-end force=true
+end
 ```
 
 Here's what this actually gets expanded to:

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ julia> foo(old_kw1=1, new_kw2=2)
 ```
 
 `@depkws` accepts an optional argument to force the deprecation warning to emit regardless of the `--depwarn` setting.
-If omitted, the default is `force=false`, which means the deprecation warning will only be shown if the user has `--depwarn=yes` set.
+If omitted, the default is `force_depwarn=false`, which means the deprecation warning will only be shown if the user has `--depwarn=yes` set.
 
 ```julia
-julia> @depkws force=true function foo(; new_kw1=2, new_kw2=3,
+julia> @depkws force_depwarn=true function foo(; new_kw1=2, new_kw2=3,
                        @deprecate(old_kw1, new_kw1),
                        @deprecate(old_kw2, new_kw2))
     return new_kw1 + new_kw2

--- a/README.md
+++ b/README.md
@@ -38,21 +38,30 @@ julia> foo(old_kw1=1, new_kw2=2)
 3
 ```
 
-(The warning uses `depwarn`, so is only visible if one starts with `--depwarn=yes`)
+`@depkws` accepts an optional argument to force the deprecation warning to emit regardless of the `--depwarn` setting.
+If omitted, the default is `false`, which means the deprecation warning will only be shown if the user has `--depwarn=yes` set.
+
+```julia
+julia> @depkws function foo(; new_kw1=2, new_kw2=3,
+                       @deprecate(old_kw1, new_kw1),
+                       @deprecate(old_kw2, new_kw2))
+    return new_kw1 + new_kw2
+end true
+```
 
 Here's what this actually gets expanded to:
 
 ```julia
 function foo(; old_kw2 = DeprecatedDefault, old_kw1 = DeprecatedDefault, new_kw1 = begin
                   if old_kw1 !== DeprecatedDefault
-                      Base.depwarn("Keyword argument `old_kw1` is deprecated. Use `new_kw1` instead.", :foo)
+                      Base.depwarn("Keyword argument `old_kw1` is deprecated. Use `new_kw1` instead.", :foo; force=true)
                       old_kw1
                   else
                       2
                   end
               end, new_kw2 = begin
                   if old_kw2 !== DeprecatedDefault
-                      Base.depwarn("Keyword argument `old_kw2` is deprecated. Use `new_kw2` instead.", :foo)
+                      Base.depwarn("Keyword argument `old_kw2` is deprecated. Use `new_kw2` instead.", :foo; force=true)
                       old_kw2
                   else
                       3

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ julia> foo(old_kw1=1, new_kw2=2)
 ```
 
 `@depkws` accepts an optional argument to force the deprecation warning to emit regardless of the `--depwarn` setting.
-If omitted, the default is `false`, which means the deprecation warning will only be shown if the user has `--depwarn=yes` set.
+If omitted, the default is `force=false`, which means the deprecation warning will only be shown if the user has `--depwarn=yes` set.
 
 ```julia
 julia> @depkws function foo(; new_kw1=2, new_kw2=3,
                        @deprecate(old_kw1, new_kw1),
                        @deprecate(old_kw2, new_kw2))
     return new_kw1 + new_kw2
-end true
+end force=true
 ```
 
 Here's what this actually gets expanded to:
@@ -54,14 +54,14 @@ Here's what this actually gets expanded to:
 ```julia
 function foo(; old_kw2 = DeprecatedDefault, old_kw1 = DeprecatedDefault, new_kw1 = begin
                   if old_kw1 !== DeprecatedDefault
-                      Base.depwarn("Keyword argument `old_kw1` is deprecated. Use `new_kw1` instead.", :foo; force=true)
+                      Base.depwarn("Keyword argument `old_kw1` is deprecated. Use `new_kw1` instead.", :foo; force = true)
                       old_kw1
                   else
                       2
                   end
               end, new_kw2 = begin
                   if old_kw2 !== DeprecatedDefault
-                      Base.depwarn("Keyword argument `old_kw2` is deprecated. Use `new_kw2` instead.", :foo; force=true)
+                      Base.depwarn("Keyword argument `old_kw2` is deprecated. Use `new_kw2` instead.", :foo; force = true)
                       old_kw2
                   else
                       3

--- a/src/DeprecateKeywords.jl
+++ b/src/DeprecateKeywords.jl
@@ -5,7 +5,7 @@ export @depkws
 using MacroTools
 
 """
-    @depkws def [force=false]
+    @depkws [force=false] def
 
 Macro to deprecate keyword arguments. Use by wrapping a function signature,
 while using `@deprecate(old_kw, new_kw)` within the function signature to deprecate.
@@ -18,13 +18,18 @@ while using `@deprecate(old_kw, new_kw)` within the function signature to deprec
 end
 
 ```julia
-@depkws function f(; a=2, @deprecate(b, a))
+# force the deprecation warning to be emitted
+@depkws force=true function f(; a=2, @deprecate(b, a))
     a
-end force=true # force the deprecation warning to be emitted
+end
 ```
 """
-macro depkws(def, force_stmt=false)
+macro depkws(force_stmt, def)
     return esc(_depkws(def, eval(force_stmt)::Bool))
+end
+
+macro depkws(def)
+    return esc(_depkws(def, false))
 end
 
 abstract type DeprecatedDefault end

--- a/src/DeprecateKeywords.jl
+++ b/src/DeprecateKeywords.jl
@@ -25,7 +25,12 @@ end
 ```
 """
 macro depkws(force_stmt, def)
-    return esc(_depkws(def, eval(force_stmt)::Bool))
+    key, val = string(force_stmt) |> x->split(x, "=")
+    key, val = rstrip(key), lstrip(val)
+    @assert key == "force" &&
+            val ∈ ["true", "false"] "First argument to @depkws must be `force=true` or `force=false`."
+    force = val == "true"
+    return esc(_depkws(def, force))
 end
 
 macro depkws(def)

--- a/src/DeprecateKeywords.jl
+++ b/src/DeprecateKeywords.jl
@@ -5,7 +5,7 @@ export @depkws
 using MacroTools
 
 """
-    @depkws [force=false] def
+    @depkws [force_depwarn=false] def
 
 Macro to deprecate keyword arguments. Use by wrapping a function signature,
 while using `@deprecate(old_kw, new_kw)` within the function signature to deprecate.
@@ -16,21 +16,24 @@ while using `@deprecate(old_kw, new_kw)` within the function signature to deprec
 @depkws function f(; a=2, @deprecate(b, a))
     a
 end
+```
 
 ```julia
 # force the deprecation warning to be emitted
-@depkws force=true function f(; a=2, @deprecate(b, a))
+@depkws force_depwarn=true function f(; a=2, @deprecate(b, a))
     a
 end
 ```
 """
 macro depkws(force_stmt, def)
-    key, val = string(force_stmt) |> x->split(x, "=")
-    key, val = rstrip(key), lstrip(val)
-    @assert key == "force" &&
-            val ∈ ["true", "false"] "First argument to @depkws must be `force=true` or `force=false`."
-    force = val == "true"
-    return esc(_depkws(def, force))
+    tokens = string(force_stmt) |> x->split(x, "=")
+    error_msg = "If two arguments are passed to @depkws, the first must be `force_depwarn=true` or `force_depwarn=false`. Got `$(force_stmt)`."
+    @assert length(tokens) == 2 error_msg
+    key, val = rstrip(tokens[1]), lstrip(tokens[2])
+    @assert key == "force_depwarn" &&
+            val ∈ ["true", "false"] error_msg
+    force_depwarn = val == "true"
+    return esc(_depkws(def, force_depwarn))
 end
 
 macro depkws(def)
@@ -39,7 +42,7 @@ end
 
 abstract type DeprecatedDefault end
 
-function _depkws(def, force)
+function _depkws(def, force_depwarn)
     sdef = splitdef(def)
     func_symbol = Expr(:quote, sdef[:name])  # Double quote for expansion
 
@@ -107,7 +110,7 @@ function _depkws(def, force)
         depwarn_string = "Keyword argument `$(deprecated_symbol)` is deprecated. Use `$(_get_symbol(new_kw))` instead."
         new_kwcall = quote
             if $deprecated_symbol !== $(DeprecatedDefault)
-                Base.depwarn($depwarn_string, $func_symbol; force=$force)
+                Base.depwarn($depwarn_string, $func_symbol; force=$force_depwarn)
                 $deprecated_symbol
             else
                 $default

--- a/src/DeprecateKeywords.jl
+++ b/src/DeprecateKeywords.jl
@@ -5,7 +5,7 @@ export @depkws
 using MacroTools
 
 """
-    @depkws [force_depwarn=false] def
+    @depkws [force=false] def
 
 Macro to deprecate keyword arguments. Use by wrapping a function signature,
 while using `@deprecate(old_kw, new_kw)` within the function signature to deprecate.
@@ -20,7 +20,7 @@ end
 
 ```julia
 # force the deprecation warning to be emitted
-@depkws force_depwarn=true function f(; a=2, @deprecate(b, a))
+@depkws force=true function f(; a=2, @deprecate(b, a))
     a
 end
 ```
@@ -44,7 +44,7 @@ function parse_options(args)
 end
 
 function default_options()
-    return Dict{Symbol, Any}(:force_depwarn => false)
+    return Dict{Symbol, Any}(:force => false)
 end
 
 abstract type DeprecatedDefault end
@@ -117,7 +117,7 @@ function _depkws(def, options)
         depwarn_string = "Keyword argument `$(deprecated_symbol)` is deprecated. Use `$(_get_symbol(new_kw))` instead."
         new_kwcall = quote
             if $deprecated_symbol !== $(DeprecatedDefault)
-                Base.depwarn($depwarn_string, $func_symbol; force=$(options[:force_depwarn]))
+                Base.depwarn($depwarn_string, $func_symbol; force=$(options[:force]))
                 $deprecated_symbol
             else
                 $default

--- a/src/DeprecateKeywords.jl
+++ b/src/DeprecateKeywords.jl
@@ -5,7 +5,7 @@ export @depkws
 using MacroTools
 
 """
-    @depkws def
+    @depkws def [force::Bool=false]
 
 Macro to deprecate keyword arguments. Use by wrapping a function signature,
 while using `@deprecate(old_kw, new_kw)` within the function signature to deprecate.
@@ -16,15 +16,20 @@ while using `@deprecate(old_kw, new_kw)` within the function signature to deprec
 @depkws function f(; a=2, @deprecate(b, a))
     a
 end
+
+```julia
+@depkws function f(; a=2, @deprecate(b, a))
+    a
+end true # force the deprecation warning to be emitted
 ```
 """
-macro depkws(def)
-    return esc(_depkws(def))
+macro depkws(def, force::Bool=false)
+    return esc(_depkws(def, force))
 end
 
 abstract type DeprecatedDefault end
 
-function _depkws(def)
+function _depkws(def, force)
     sdef = splitdef(def)
     func_symbol = Expr(:quote, sdef[:name])  # Double quote for expansion
 
@@ -92,7 +97,7 @@ function _depkws(def)
         depwarn_string = "Keyword argument `$(deprecated_symbol)` is deprecated. Use `$(_get_symbol(new_kw))` instead."
         new_kwcall = quote
             if $deprecated_symbol !== $(DeprecatedDefault)
-                Base.depwarn($depwarn_string, $func_symbol)
+                Base.depwarn($depwarn_string, $func_symbol; force=$force)
                 $deprecated_symbol
             else
                 $default

--- a/src/DeprecateKeywords.jl
+++ b/src/DeprecateKeywords.jl
@@ -25,24 +25,31 @@ end
 end
 ```
 """
-macro depkws(force_stmt, def)
-    tokens = string(force_stmt) |> x->split(x, "=")
-    error_msg = "If two arguments are passed to @depkws, the first must be `force_depwarn=true` or `force_depwarn=false`. Got `$(force_stmt)`."
-    @assert length(tokens) == 2 error_msg
-    key, val = rstrip(tokens[1]), lstrip(tokens[2])
-    @assert key == "force_depwarn" &&
-            val ∈ ["true", "false"] error_msg
-    force_depwarn = val == "true"
-    return esc(_depkws(def, force_depwarn))
+macro depkws(args...)
+    options = parse_options(args[1:end-1])
+    return esc(_depkws(args[end], options))
 end
 
-macro depkws(def)
-    return esc(_depkws(def, false))
+function parse_options(args)
+    options = default_options()
+    for arg in args
+        if isa(arg, Expr) && arg.head == :(=)
+            @assert arg.args[1] ∈ keys(options) "Unknown option: $(arg.args[1])"
+            options[arg.args[1]] = arg.args[2]
+        else
+            error("Invalid option: $arg")
+        end
+    end
+    return options
+end
+
+function default_options()
+    return Dict{Symbol, Any}(:force_depwarn => false)
 end
 
 abstract type DeprecatedDefault end
 
-function _depkws(def, force_depwarn)
+function _depkws(def, options)
     sdef = splitdef(def)
     func_symbol = Expr(:quote, sdef[:name])  # Double quote for expansion
 
@@ -110,7 +117,7 @@ function _depkws(def, force_depwarn)
         depwarn_string = "Keyword argument `$(deprecated_symbol)` is deprecated. Use `$(_get_symbol(new_kw))` instead."
         new_kwcall = quote
             if $deprecated_symbol !== $(DeprecatedDefault)
-                Base.depwarn($depwarn_string, $func_symbol; force=$force_depwarn)
+                Base.depwarn($depwarn_string, $func_symbol; force=$(options[:force_depwarn]))
                 $deprecated_symbol
             else
                 $default

--- a/src/DeprecateKeywords.jl
+++ b/src/DeprecateKeywords.jl
@@ -5,7 +5,7 @@ export @depkws
 using MacroTools
 
 """
-    @depkws def [force::Bool=false]
+    @depkws def [force=false]
 
 Macro to deprecate keyword arguments. Use by wrapping a function signature,
 while using `@deprecate(old_kw, new_kw)` within the function signature to deprecate.
@@ -20,11 +20,11 @@ end
 ```julia
 @depkws function f(; a=2, @deprecate(b, a))
     a
-end true # force the deprecation warning to be emitted
+end force=true # force the deprecation warning to be emitted
 ```
 """
-macro depkws(def, force::Bool=false)
-    return esc(_depkws(def, force))
+macro depkws(def, force_stmt=false)
+    return esc(_depkws(def, eval(force_stmt)::Bool))
 end
 
 abstract type DeprecatedDefault end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using DeprecateKeywords
 @testset "Basic" begin
     @depkws function f(; a=2, @deprecate b a)
         a
-    end
+    end true # force the deprecation warning to be emitted
 
     @test f(a=1) === 1
     VERSION >= v"1.8" && @test_warn "Keyword argument `b` is deprecated. Use `a` instead." (@test f(b=1) == 1)
@@ -15,7 +15,7 @@ end
 @testset "Multi-param" begin
     @depkws function g(; α=2, γ=4, @deprecate(β, α), @deprecate(δ, γ))
         α + γ
-    end
+    end false # do not force the deprecation warning to be emitted (default behavior)
 
     @test g() === 6
     @test g(α=1, γ=3) === 4
@@ -27,6 +27,7 @@ end
 end
 
 @testset "With types" begin
+    # default behavior is to not emit deprecation warnings, so it will not be emitted
     @depkws h(; (@deprecate old_kw new_kw), new_kw::Int=3) = new_kw
     @test h() === 3
     @test h(new_kw=1) === 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using DeprecateKeywords
 
 @testset "Basic" begin
     # force the deprecation warning to be emitted
-    @depkws force_depwarn=true function f(; a=2, @deprecate b a)
+    @depkws force=true function f(; a=2, @deprecate b a)
         a
     end
 
@@ -15,7 +15,7 @@ end
 
 @testset "Multi-param" begin
     # do not force the deprecation warning to be emitted (default behavior)
-    @depkws force_depwarn=false function g(; α=2, γ=4, @deprecate(β, α), @deprecate(δ, γ))
+    @depkws force=false function g(; α=2, γ=4, @deprecate(β, α), @deprecate(δ, γ))
         α + γ
     end
 
@@ -60,4 +60,11 @@ end
     VERSION >= v"1.8" && @test_throws UndefKeywordError k(1.0)
     VERSION >= v"1.8" && @test_warn "Keyword argument" (@test k(1.0; a=2.0) == 3.0)
     @test k(1.0; b=2.0) == 3.0
+end
+
+@testset "Name conflicts" begin
+    @depkws force(; a="cat", @deprecate(b, a)) = a
+    VERSION >= v"1.8" && @test_warn "Keyword argument" (@test force(b="dog") == "dog")
+    @test macroexpand(DeprecateKeywords, :(@depkws force(; a="cat", @deprecate(b, a)) = a)) |> string |> contains("force = false")
+    @test macroexpand(DeprecateKeywords, :(@depkws force=true force(; a="cat", @deprecate(b, a)) = a)) |> string |> contains("force = true")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using DeprecateKeywords
 @testset "Basic" begin
     @depkws function f(; a=2, @deprecate b a)
         a
-    end true # force the deprecation warning to be emitted
+    end force=true # force the deprecation warning to be emitted
 
     @test f(a=1) === 1
     VERSION >= v"1.8" && @test_warn "Keyword argument `b` is deprecated. Use `a` instead." (@test f(b=1) == 1)
@@ -15,7 +15,7 @@ end
 @testset "Multi-param" begin
     @depkws function g(; α=2, γ=4, @deprecate(β, α), @deprecate(δ, γ))
         α + γ
-    end false # do not force the deprecation warning to be emitted (default behavior)
+    end force=false # do not force the deprecation warning to be emitted (default behavior)
 
     @test g() === 6
     @test g(α=1, γ=3) === 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using DeprecateKeywords
 
 @testset "Basic" begin
     # force the deprecation warning to be emitted
-    @depkws force=true function f(; a=2, @deprecate b a)
+    @depkws force_depwarn=true function f(; a=2, @deprecate b a)
         a
     end
 
@@ -15,7 +15,7 @@ end
 
 @testset "Multi-param" begin
     # do not force the deprecation warning to be emitted (default behavior)
-    @depkws force=false function g(; α=2, γ=4, @deprecate(β, α), @deprecate(δ, γ))
+    @depkws force_depwarn=false function g(; α=2, γ=4, @deprecate(β, α), @deprecate(δ, γ))
         α + γ
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,10 @@ using Test
 using DeprecateKeywords
 
 @testset "Basic" begin
-    @depkws function f(; a=2, @deprecate b a)
+    # force the deprecation warning to be emitted
+    @depkws force=true function f(; a=2, @deprecate b a)
         a
-    end force=true # force the deprecation warning to be emitted
+    end
 
     @test f(a=1) === 1
     VERSION >= v"1.8" && @test_warn "Keyword argument `b` is deprecated. Use `a` instead." (@test f(b=1) == 1)
@@ -13,9 +14,10 @@ using DeprecateKeywords
 end
 
 @testset "Multi-param" begin
-    @depkws function g(; α=2, γ=4, @deprecate(β, α), @deprecate(δ, γ))
+    # do not force the deprecation warning to be emitted (default behavior)
+    @depkws force=false function g(; α=2, γ=4, @deprecate(β, α), @deprecate(δ, γ))
         α + γ
-    end force=false # do not force the deprecation warning to be emitted (default behavior)
+    end
 
     @test g() === 6
     @test g(α=1, γ=3) === 4


### PR DESCRIPTION
not the prettiest signature, but functional and easy to implement:
```
@depkws function foo(; new_kw1=2, new_kw2=3,
                       @deprecate(old_kw1, new_kw1),
                       @deprecate(old_kw2, new_kw2))
    return new_kw1 + new_kw2
end true # <-- true sets the boolean for the force kwarg of Base.depwarn
```
This will force the depwarn to emit (the first time) so it can also be user-facing and not just dev-facing